### PR TITLE
🔀 :: (#13) 각 Auth페이지에 상태관리와 기능 추가 

### DIFF
--- a/lib/core/design_system/component/text_field/gogo_text_field.dart
+++ b/lib/core/design_system/component/text_field/gogo_text_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../theme/color.dart';
 import '../../theme/icon.dart';
@@ -12,7 +13,7 @@ enum GogoTextFieldState {
 class GogoTextField extends StatefulWidget {
   final GogoTextFieldState textFieldState;
   final TextEditingController controller;
-  final String? validator;
+  final Function(String?)? validator;
   final Color backgroundColor;
   final Color textColor;
   final BorderRadius borderRadius;
@@ -31,6 +32,8 @@ class GogoTextField extends StatefulWidget {
   final Color searchIconColor;
   final EdgeInsetsGeometry passwordIconPadding;
   final double passwordIconSize;
+  final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatter;
 
   const GogoTextField({
     super.key,
@@ -39,8 +42,10 @@ class GogoTextField extends StatefulWidget {
     required this.hintText,
     this.validator,
     this.onEditingComplete,
+    this.keyboardType,
+    this.inputFormatter,
     this.textColor = GogoColors.white,
-    this.backgroundColor= GogoColors.gray700,
+    this.backgroundColor = GogoColors.gray700,
     this.borderRadius = const BorderRadius.all(Radius.circular(12)),
     this.textStyle = GogoTypography.body3Semibold,
     this.cursorColor = GogoColors.main600,
@@ -74,11 +79,13 @@ class _GogoTextFieldState extends State<GogoTextField> {
       validator: (value) {
         if (widget.textFieldState == GogoTextFieldState.basic &&
             widget.validator != null) {
-          return widget.validator;
+          return widget.validator!(value);  // 이 부분을 수정
         } else {
           return null;
         }
       },
+      keyboardType: widget.keyboardType,
+      inputFormatters: widget.inputFormatter,
       style: widget.textStyle.copyWith(color: widget.textColor),
       cursorColor: widget.cursorColor,
       cursorErrorColor: widget.cursorErrorColor,
@@ -113,6 +120,60 @@ class _GogoTextFieldState extends State<GogoTextField> {
           borderRadius: widget.borderRadius,
           borderSide: widget.errorBorderSide,
         ),
+      ),
+    );
+  }
+}
+
+class GradeSuffixInputFormatter extends TextInputFormatter {
+  final String suffix = "학년";
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.endsWith(suffix)) {
+      return newValue;
+    }
+    return TextEditingValue(
+      text: newValue.text + suffix,
+      selection: TextSelection.fromPosition(
+        TextPosition(offset: newValue.text.length),
+      ),
+    );
+  }
+}
+
+class NumberSuffixInputFormatter extends TextInputFormatter {
+  final String suffix = "번";
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.endsWith(suffix)) {
+      return newValue;
+    }
+    return TextEditingValue(
+      text: newValue.text + suffix,
+      selection: TextSelection.fromPosition(
+        TextPosition(offset: newValue.text.length),
+      ),
+    );
+  }
+}
+
+class ClassSuffixInputFormatter extends TextInputFormatter {
+  final String suffix = "반";
+
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.endsWith(suffix)) {
+      return newValue;
+    }
+    return TextEditingValue(
+      text: newValue.text + suffix,
+      selection: TextSelection.fromPosition(
+        TextPosition(offset: newValue.text.length),
       ),
     );
   }

--- a/lib/presentation/logIn/screen/login_screen.dart
+++ b/lib/presentation/logIn/screen/login_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:gogo_app/presentation/sign_up/screen/sign_up_screen.dart';
-import 'package:gogo_app/router.dart';
 import '../../../core/design_system/theme/color.dart';
 import '../../../core/design_system/theme/icon.dart';
 import '../../logIn/widgets/google_login_button.dart';

--- a/lib/presentation/logIn/screen/login_screen.dart
+++ b/lib/presentation/logIn/screen/login_screen.dart
@@ -1,4 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:gogo_app/presentation/sign_up/screen/sign_up_screen.dart';
+import 'package:gogo_app/router.dart';
 import '../../../core/design_system/theme/color.dart';
 import '../../../core/design_system/theme/icon.dart';
 import '../../logIn/widgets/google_login_button.dart';
@@ -19,7 +23,7 @@ class LogInScreen extends StatelessWidget {
               width: double.infinity,
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(12),
-                child: GoogleLoginButton(onPressed: () {}),
+                child: GoogleLoginButton(onPressed: () => Navigator.push(context, CupertinoPageRoute(builder: (_) => SignUpScreen()))),
               ),
             ),
           ),

--- a/lib/presentation/sign_up/bloc/name/name_bloc.dart
+++ b/lib/presentation/sign_up/bloc/name/name_bloc.dart
@@ -1,0 +1,46 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/name/name_event.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/name/name_state.dart';
+
+class NameBloc extends Bloc<NameEvent, NameState> {
+  final TextEditingController _nameController;
+
+  TextEditingController get nameController => _nameController;
+
+  NameBloc(this._nameController) : super(DisableNameState()) {
+    on<EnterNameEvent>(_handlerEnterNameEvent);
+    _nameController.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    add(EnterNameEvent());
+  }
+
+  String? validateName(String? value) {
+    if (value == null || value.isEmpty) {
+      return '이름을 입력해주세요.';
+    }
+    // 이름이 최소 2글자 이상이어야 함
+    if (value.length < 2) {
+      return '이름은 최소 2글자 이상이어야 합니다.';
+    }
+    // 이름에 숫자나 특수문자가 포함되지 않도록 검증
+    if (!RegExp(r'^[a-zA-Z가-힣]+$').hasMatch(value)) {
+      return '이름에는 숫자나 특수문자가 포함될 수 없습니다.';
+    }
+    return null; // 유효성 검사 통과
+  }
+
+  void _handlerEnterNameEvent(EnterNameEvent event, Emitter<NameState> emit) {
+    validateName(_nameController.text) == null && _nameController.text.isNotEmpty
+        ? emit(EnableNameState())
+        : emit(DisableNameState());
+  }
+  @override
+  Future<void> close() {
+    _nameController.removeListener(_onTextChanged); // 리스너 제거
+    return super.close();
+  }
+
+}

--- a/lib/presentation/sign_up/bloc/name/name_event.dart
+++ b/lib/presentation/sign_up/bloc/name/name_event.dart
@@ -1,0 +1,3 @@
+abstract class NameEvent {}
+
+class EnterNameEvent extends NameEvent {}

--- a/lib/presentation/sign_up/bloc/name/name_state.dart
+++ b/lib/presentation/sign_up/bloc/name/name_state.dart
@@ -1,0 +1,5 @@
+abstract class NameState {}
+
+class DisableNameState extends NameState {}
+
+class EnableNameState extends NameState {}

--- a/lib/presentation/sign_up/bloc/number/number_bloc.dart
+++ b/lib/presentation/sign_up/bloc/number/number_bloc.dart
@@ -1,0 +1,84 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/number/number_event.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/number/number_state.dart';
+
+class NumberBloc extends Bloc<NumberEvent, NumberState> {
+  final TextEditingController _gradeController;
+  final TextEditingController _classController;
+  final TextEditingController _numberController;
+
+  TextEditingController get gradeController => _gradeController;
+
+  TextEditingController get classController => _classController;
+
+  TextEditingController get numberController => _numberController;
+
+  NumberBloc(
+      this._gradeController, this._classController, this._numberController)
+      : super(DisableNumberState()) {
+    on<EnterNumberEvent>(_handlerEnterNumberEvent);
+
+    _gradeController.addListener(_onTextChanged);
+    _classController.addListener(_onTextChanged);
+    _numberController.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    add(EnterNumberEvent());
+  }
+
+  String? gradeValidator(String? value) {
+    if (value == null || value.isEmpty) {
+      return '학년을 입력해주세요.';
+    }
+    final number = int.tryParse(value.replaceAll('학년', '').trim());
+    if (number == null || number < 1 || number > 6) {
+      return '학년은 1~6 사이의 숫자여야 합니다.';
+    }
+    return null;
+  }
+
+  String? classValidator(String? value) {
+    if (value == null || value.isEmpty) {
+      return '반을 입력해주세요.';
+    }
+    final number = int.tryParse(value.replaceAll('반', '').trim());
+    if (number == null || number < 1 || number > 30) {
+      return '반은 1~30 사이의 숫자여야 합니다.';
+    }
+    return null;
+  }
+
+  String? numberValidator(String? value) {
+    if (value == null || value.isEmpty) {
+      return '번호를 입력해주세요.';
+    }
+    final number = int.tryParse(value.replaceAll('번', '').trim());
+    if (number == null || number < 1 || number > 50) {
+      return '번호는 1~50 사이의 숫자여야 합니다.';
+    }
+    return null;
+  }
+
+  void _handlerEnterNumberEvent(
+      EnterNumberEvent event, Emitter<NumberState> emit) {
+    final isValidGrade = gradeValidator(_gradeController.text) == null;
+    final isValidClass = classValidator(_classController.text) == null;
+    final isValidNumber = numberValidator(_numberController.text) == null;
+
+    if (isValidGrade && isValidClass && isValidNumber) {
+      emit(EnableNumberState());
+    } else {
+      emit(DisableNumberState());
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _gradeController.removeListener(_onTextChanged); // 리스너 제거
+    _classController.removeListener(_onTextChanged); // 리스너 제거
+    _numberController.removeListener(_onTextChanged); // 리스너 제거
+    return super.close();
+  }
+}

--- a/lib/presentation/sign_up/bloc/number/number_event.dart
+++ b/lib/presentation/sign_up/bloc/number/number_event.dart
@@ -1,0 +1,3 @@
+abstract class NumberEvent{}
+
+class EnterNumberEvent extends NumberEvent{}

--- a/lib/presentation/sign_up/bloc/number/number_state.dart
+++ b/lib/presentation/sign_up/bloc/number/number_state.dart
@@ -1,0 +1,5 @@
+abstract class NumberState {}
+
+class EnableNumberState extends NumberState {}
+
+class DisableNumberState extends NumberState {}

--- a/lib/presentation/sign_up/bloc/school/school_bloc.dart
+++ b/lib/presentation/sign_up/bloc/school/school_bloc.dart
@@ -1,0 +1,31 @@
+import 'package:bloc/bloc.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/school/school_event.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/school/school_state.dart';
+
+class SchoolBloc extends Bloc<SchoolEvent, SchoolState> {
+  final TextEditingController _schoolController;
+
+  TextEditingController get schoolController => _schoolController;
+
+  SchoolBloc(this._schoolController) : super(DisableSchoolState()) {
+    on<EnterSchoolEvent>(_handlerEnterSchoolEvent);
+    _schoolController.addListener(_onTextChanged);
+  }
+
+  void _onTextChanged() {
+    add(EnterSchoolEvent());
+  }
+
+  void _handlerEnterSchoolEvent(EnterSchoolEvent event, Emitter<SchoolState> emit) {
+    _schoolController.text.isNotEmpty
+        ? emit(EnableSchoolState())
+        : emit(DisableSchoolState());
+  }
+  @override
+  Future<void> close() {
+    _schoolController.removeListener(_onTextChanged); // 리스너 제거
+    return super.close();
+  }
+
+}

--- a/lib/presentation/sign_up/bloc/school/school_event.dart
+++ b/lib/presentation/sign_up/bloc/school/school_event.dart
@@ -1,0 +1,3 @@
+abstract class SchoolEvent{}
+
+class EnterSchoolEvent extends SchoolEvent{}

--- a/lib/presentation/sign_up/bloc/school/school_state.dart
+++ b/lib/presentation/sign_up/bloc/school/school_state.dart
@@ -1,0 +1,5 @@
+abstract class SchoolState {}
+
+class DisableSchoolState extends SchoolState {}
+
+class EnableSchoolState extends SchoolState {}

--- a/lib/presentation/sign_up/bloc/sex/sex_bloc.dart
+++ b/lib/presentation/sign_up/bloc/sex/sex_bloc.dart
@@ -1,0 +1,30 @@
+import 'package:bloc/bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/sex/sex_event.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/sex/sex_state.dart';
+
+class SexBloc extends Bloc<SexEvent, SexState> {
+  Sex? _sexController;
+
+  Sex? get sexController => _sexController;
+
+  set sexController(Sex? sex) {
+    _sexController = sex;
+    add(EnterSexEvent());
+  }
+
+  SexBloc(this._sexController) : super(DisableSexState()) {
+    on<EnterSexEvent>(_handlerEnterSexEvent);
+  }
+
+  void _handlerEnterSexEvent(SexEvent event, Emitter<SexState> emit) {
+    if (_sexController == null) {
+      emit(DisableSexState());
+    }
+    if (_sexController == Sex.male) {
+      emit(EnableMaleSexState());
+    }
+    if (_sexController == Sex.female) {
+      emit(EnableFemaleSexState());
+    }
+  }
+}

--- a/lib/presentation/sign_up/bloc/sex/sex_event.dart
+++ b/lib/presentation/sign_up/bloc/sex/sex_event.dart
@@ -1,0 +1,3 @@
+abstract class SexEvent{}
+
+class EnterSexEvent extends SexEvent{}

--- a/lib/presentation/sign_up/bloc/sex/sex_state.dart
+++ b/lib/presentation/sign_up/bloc/sex/sex_state.dart
@@ -1,0 +1,10 @@
+enum Sex { male, female }
+
+abstract class SexState {}
+class DisableSexState extends SexState {}
+
+abstract class EnableSexState extends SexState{}
+
+class EnableMaleSexState extends EnableSexState {}
+
+class EnableFemaleSexState extends EnableSexState {}

--- a/lib/presentation/sign_up/screen/sign_up_screen.dart
+++ b/lib/presentation/sign_up/screen/sign_up_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/name/name_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/school/school_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/sex/sex_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/widgets/page/name_page.dart';
+import 'package:gogo_app/presentation/sign_up/widgets/page/number_page.dart';
+import 'package:gogo_app/presentation/sign_up/widgets/page/school_page.dart';
+import 'package:gogo_app/presentation/sign_up/widgets/page/sex_page.dart';
+import '../bloc/number/number_bloc.dart';
+import '../bloc/sex/sex_state.dart';
+
+class SignUpScreen extends StatelessWidget {
+  const SignUpScreen({super.key});
+
+  static PageController pageController = PageController();
+  static final TextEditingController nameController = TextEditingController();
+  static final TextEditingController schoolController = TextEditingController();
+  static final TextEditingController gradeController = TextEditingController();
+  static final TextEditingController classController = TextEditingController();
+  static final TextEditingController numberController = TextEditingController();
+  static Sex? sexController;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (_) => NameBloc(nameController)),
+        BlocProvider(
+            create: (_) => NumberBloc(
+                  gradeController,
+                  classController,
+                  numberController,
+                )),
+        BlocProvider(create: (_) => SchoolBloc(schoolController)),
+        BlocProvider(create: (_) => SexBloc(sexController)),
+      ],
+      child: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 50, 16, 95),
+              child: PageView(
+                controller: pageController,
+                physics: NeverScrollableScrollPhysics(),
+                children: [
+                  SchoolPage(
+                    onBackClick: () => _navigatorPage(context, -1),
+                    onNextClick: () => _navigatorPage(context, 1),
+                  ),
+                  NamePage(
+                    onBackClick: () => _navigatorPage(context, 0),
+                    onNextClick: () => _navigatorPage(context, 2),
+                  ),
+                  NumberPage(
+                    onBackClick: () => _navigatorPage(context, 1),
+                    onNextClick: () => _navigatorPage(context, 3),
+                  ),
+                  SexPage(
+                    onBackClick: () => _navigatorPage(context, 2),
+                    onNextClick: () => _navigatorPage(context, 4),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _navigatorPage(BuildContext context, int index) {
+    FocusScope.of(context).unfocus();
+    if (index == -1) {
+      Navigator.pop(context);
+      nameController.text = "";
+      schoolController.text = "";
+      gradeController.text = "";
+      classController.text = "";
+      numberController.text = "";
+      sexController = null;
+    } else {
+      pageController.animateToPage(index,
+          duration: Duration(milliseconds: 300), curve: Curves.ease);
+    }
+  }
+}

--- a/lib/presentation/sign_up/widgets/page/name_page.dart
+++ b/lib/presentation/sign_up/widgets/page/name_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/name/name_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/name/name_state.dart';
 import '../../../../core/design_system/component/button/gogo_default_button.dart';
 import '../../../../core/design_system/component/text_field/gogo_text_field.dart';
 import '../../../../core/design_system/theme/color.dart';
@@ -6,45 +9,54 @@ import '../../../../core/design_system/theme/icon.dart';
 import '../../../../core/design_system/theme/typography.dart';
 
 class NamePage extends StatelessWidget {
-  const NamePage({super.key});
+  final VoidCallback onBackClick;
+  final VoidCallback onNextClick;
+
+  const NamePage({
+    super.key,
+    required this.onBackClick,
+    required this.onNextClick,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: ()=>FocusScope.of(context).unfocus(),
-      child: Scaffold(
-        backgroundColor: GogoColors.black,
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 50, 16, 95),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                GogoIcons.chevronLeft(
-                  color: GogoColors.white,
-                  width: 40,
-                  height: 40,
-                  onTap: () {},
-                ),
-                SizedBox(height: 40),
-                Text(
-                  "이름을 알려주세요.",
-                  style: GogoTypography.title3Extrabold.copyWith(color: GogoColors.white),
-                ),
-                SizedBox(height: 36,),
-                GogoTextField(
-                  textFieldState: GogoTextFieldState.basic,
-                  controller: TextEditingController(),
-                  hintText: "이름를 입력해주세요.",
-                ),
-                Spacer(),
-                GogoDefaultButton(
-                    onTap: () {}, text: "다음")
-              ],
+    return BlocBuilder<NameBloc, NameState>(
+      builder: (context, state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GogoIcons.chevronLeft(
+              color: GogoColors.white,
+              width: 40,
+              height: 40,
+              onTap: onBackClick,
             ),
-          ),
-        ),
-      ),
+            SizedBox(height: 40),
+            Text(
+              "이름을 알려주세요.",
+              style:
+                  GogoTypography.title3Extrabold.copyWith(color: GogoColors.white),
+            ),
+            SizedBox(
+              height: 36,
+            ),
+            GogoTextField(
+              textFieldState: GogoTextFieldState.basic,
+              controller: context.read<NameBloc>().nameController,
+              hintText: "이름를 입력해주세요.",
+              validator: context.read<NameBloc>().validateName,
+            ),
+            Spacer(),
+            GogoDefaultButton(
+              onTap: state is EnableNameState ? onNextClick : () {},
+              text: "다음",
+              color: state is EnableNameState
+                  ? GogoColors.main600
+                  : GogoColors.gray400,
+            ),
+          ],
+        );
+      }
     );
   }
 }

--- a/lib/presentation/sign_up/widgets/page/number_page.dart
+++ b/lib/presentation/sign_up/widgets/page/number_page.dart
@@ -1,70 +1,99 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/number/number_state.dart';
 import '../../../../core/design_system/component/button/gogo_default_button.dart';
 import '../../../../core/design_system/component/text_field/gogo_text_field.dart';
 import '../../../../core/design_system/theme/color.dart';
 import '../../../../core/design_system/theme/icon.dart';
 import '../../../../core/design_system/theme/typography.dart';
-
+import '../../bloc/number/number_bloc.dart';
 
 class NumberPage extends StatelessWidget {
-  const NumberPage({super.key});
+  const NumberPage({
+    super.key,
+    required this.onBackClick,
+    required this.onNextClick,
+  });
+
+  final VoidCallback onBackClick;
+  final VoidCallback onNextClick;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => FocusScope.of(context).unfocus(),
-      child: Scaffold(
-        body: SafeArea(
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(16, 50, 16, 93),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                GogoIcons.chevronLeft(
-                  color: GogoColors.white,
-                  width: 40,
-                  height: 40,
-                  onTap: () {},
-                ),
-                SizedBox(
-                  height: 40,
-                ),
-                Text(
-                  '반과 번호를 알려주세요',
-                  style: GogoTypography.title4Extrabold
-                      .copyWith(color: GogoColors.white),
-                ),
-                SizedBox(
-                  height: 36,
-                ),
-                GogoTextField(
-                  textFieldState: GogoTextFieldState.basic,
-                  controller: TextEditingController(),
-                  hintText: "학년",
-                ),
-                SizedBox(
-                  height: 12,
-                ),
-                GogoTextField(
-                  textFieldState: GogoTextFieldState.basic,
-                  controller: TextEditingController(),
-                  hintText: "반",
-                ),
-                SizedBox(
-                  height: 12,
-                ),
-                GogoTextField(
-                  textFieldState: GogoTextFieldState.basic,
-                  controller: TextEditingController(),
-                  hintText: "번호",
-                ),
-                Spacer(),
-                GogoDefaultButton(onTap: () {}, text: "다음")
-              ],
-            ),
+    return BlocBuilder<NumberBloc, NumberState>(builder: (context, state) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GogoIcons.chevronLeft(
+            color: GogoColors.white,
+            width: 40,
+            height: 40,
+            onTap: onBackClick,
           ),
-        ),
-      ),
-    );
+          SizedBox(
+            height: 40,
+          ),
+          Text(
+            '반과 번호를 알려주세요',
+            style: GogoTypography.title4Extrabold
+                .copyWith(color: GogoColors.white),
+          ),
+          SizedBox(
+            height: 36,
+          ),
+          GogoTextField(
+            textFieldState: GogoTextFieldState.basic,
+            controller: context.read<NumberBloc>().gradeController,
+            hintText: "학년",
+            validator: context.read<NumberBloc>().gradeValidator,
+            keyboardType: TextInputType.number,
+            inputFormatter: [
+              FilteringTextInputFormatter(RegExp('[1-6]'), allow: true),
+              LengthLimitingTextInputFormatter(1),
+              GradeSuffixInputFormatter(),
+            ],
+          ),
+          SizedBox(
+            height: 12,
+          ),
+          GogoTextField(
+            textFieldState: GogoTextFieldState.basic,
+            controller: context.read<NumberBloc>().classController,
+            hintText: "반",
+            validator: context.read<NumberBloc>().classValidator,
+            keyboardType: TextInputType.number,
+            inputFormatter: [
+              FilteringTextInputFormatter(RegExp('[0-9]'), allow: true),
+              LengthLimitingTextInputFormatter(2),
+              ClassSuffixInputFormatter()
+            ],
+          ),
+          SizedBox(
+            height: 12,
+          ),
+          GogoTextField(
+            textFieldState: GogoTextFieldState.basic,
+            controller: context.read<NumberBloc>().numberController,
+            hintText: "번호",
+            validator: context.read<NumberBloc>().numberValidator,
+            keyboardType: TextInputType.number,
+            inputFormatter: [
+              FilteringTextInputFormatter(RegExp('[0-9]'), allow: true),
+              LengthLimitingTextInputFormatter(2),
+              NumberSuffixInputFormatter()
+            ],
+          ),
+          Spacer(),
+          GogoDefaultButton(
+            onTap: state is EnableNumberState ? onNextClick : () {},
+            text: "다음",
+            color: state is EnableNumberState
+                ? GogoColors.main600
+                : GogoColors.gray400,
+          ),
+        ],
+      );
+    });
   }
 }

--- a/lib/presentation/sign_up/widgets/page/school_page.dart
+++ b/lib/presentation/sign_up/widgets/page/school_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/school/school_bloc.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/school/school_state.dart';
 import '../../../../core/design_system/component/button/gogo_default_button.dart';
 import '../../../../core/design_system/component/text_field/gogo_text_field.dart';
 import '../../../../core/design_system/theme/color.dart';
@@ -6,47 +9,50 @@ import '../../../../core/design_system/theme/icon.dart';
 import '../../../../core/design_system/theme/typography.dart';
 
 class SchoolPage extends StatelessWidget {
-  const SchoolPage({super.key});
+  const SchoolPage({
+    super.key,
+    required this.onBackClick,
+    required this.onNextClick,
+  });
+
+  final VoidCallback onBackClick;
+  final VoidCallback onNextClick;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: ()=> FocusScope.of(context).unfocus(),
-      child: Scaffold(
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 50, 16, 95),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                GogoIcons.chevronLeft(
-                  color: GogoColors.white,
-                  width: 40,
-                  height: 40,
-                  onTap: () {},
-                ),
-                SizedBox(height: 40),
-                Text(
-                  "학교를 알려주세요.",
-                  style: GogoTypography.title3Extrabold
-                      .copyWith(color: GogoColors.white),
-                ),
-                SizedBox(
-                  height: 36,
-                ),
-                GogoTextField(
-                  textFieldState: GogoTextFieldState.search,
-                  controller: TextEditingController(),
-                  hintText: "학교를 입력해주세요.",
-                ),
-                Spacer(),
-                GogoDefaultButton(
-                    onTap: () {}, text: "다음")
-              ],
-            ),
+    return BlocBuilder<SchoolBloc, SchoolState>(builder: (context, state) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GogoIcons.chevronLeft(
+              color: GogoColors.white,
+              width: 40,
+              height: 40,
+              onTap: onBackClick),
+          SizedBox(height: 40),
+          Text(
+            "학교를 알려주세요.",
+            style: GogoTypography.title3Extrabold
+                .copyWith(color: GogoColors.white),
           ),
-        ),
-      ),
-    );
+          SizedBox(
+            height: 36,
+          ),
+          GogoTextField(
+            textFieldState: GogoTextFieldState.search,
+            controller: context.read<SchoolBloc>().schoolController,
+            hintText: "학교를 입력해주세요.",
+          ),
+          Spacer(),
+          GogoDefaultButton(
+            onTap: state is EnableSchoolState ? onNextClick : () {},
+            text: "다음",
+            color: state is EnableSchoolState
+                ? GogoColors.main600
+                : GogoColors.gray400,
+          ),
+        ],
+      );
+    });
   }
 }

--- a/lib/presentation/sign_up/widgets/page/sex_page.dart
+++ b/lib/presentation/sign_up/widgets/page/sex_page.dart
@@ -1,47 +1,75 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:gogo_app/presentation/sign_up/bloc/sex/sex_bloc.dart';
 import '../../../../core/design_system/component/button/gogo_default_button.dart';
 import '../../../../core/design_system/theme/color.dart';
 import '../../../../core/design_system/theme/icon.dart';
 import '../../../../core/design_system/theme/typography.dart';
+import '../../bloc/sex/sex_state.dart';
 
 class SexPage extends StatelessWidget {
-  const SexPage({super.key});
+  const SexPage({
+    super.key,
+    required this.onBackClick,
+    required this.onNextClick,
+  });
+
+  final VoidCallback onBackClick;
+  final VoidCallback onNextClick;
 
   @override
   Widget build(BuildContext context) {
-    return  Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.fromLTRB(16, 50, 16, 93),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              GogoIcons.chevronLeft(
-                color: GogoColors.white,
-                width: 40,
-                height: 40,
-                onTap: () {},
-              ),
-              SizedBox(
-                height: 40,
-              ),
-              Text(
-                '반과 번호를 알려주세요',
-                style: GogoTypography.title4Extrabold
-                    .copyWith(color: GogoColors.white),
-              ),
-              SizedBox(
-                height: 36,
-              ),
-              GogoDefaultButton(onTap: (){}, text: "남성"),
-              SizedBox(height: 12,),
-              GogoDefaultButton(onTap: (){}, text: "여성"),
-              Spacer(),
-              GogoDefaultButton(onTap: () {}, text: "다음")
-            ],
-          ),
-        ),
-      ),
+    return BlocBuilder<SexBloc, SexState>(
+      builder: (context, state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GogoIcons.chevronLeft(
+              color: GogoColors.white,
+              width: 40,
+              height: 40,
+              onTap: onBackClick,
+            ),
+            SizedBox(
+              height: 40,
+            ),
+            Text(
+              '반과 번호를 알려주세요',
+              style:
+                  GogoTypography.title4Extrabold.copyWith(color: GogoColors.white),
+            ),
+            SizedBox(
+              height: 36,
+            ),
+            GogoDefaultButton(
+              onTap: ()=> context.read<SexBloc>().sexController = Sex.male,
+              text: "남성",
+              color: state is EnableMaleSexState
+                  ? GogoColors.main600
+                  : GogoColors.gray400,
+            ),
+            SizedBox(
+              height: 12,
+            ),
+            GogoDefaultButton(
+              onTap: ()=>context.read<SexBloc>().sexController = Sex.female,
+              text: "여성",
+              color: state is EnableFemaleSexState
+                  ? GogoColors.main600
+                  : GogoColors.gray400,
+            ),
+            Spacer(),
+            GogoDefaultButton(
+              onTap: state is EnableSexState ? onNextClick : () {},
+              text: "다음",
+              color: state is EnableSexState
+                  ? GogoColors.main600
+                  : GogoColors.gray400,
+            ),
+          ],
+        );
+      }
     );
   }
 }

--- a/lib/presentation/sign_up/widgets/page/sex_page.dart
+++ b/lib/presentation/sign_up/widgets/page/sex_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
 import 'package:gogo_app/presentation/sign_up/bloc/sex/sex_bloc.dart';
 import '../../../../core/design_system/component/button/gogo_default_button.dart';
 import '../../../../core/design_system/theme/color.dart';

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,6 +1,7 @@
 import 'package:go_router/go_router.dart';
 import 'package:gogo_app/presentation/logIn/screen/login_screen.dart';
-import 'package:gogo_app/presentation/sign_up/widgets/page/sex_page.dart';
+import 'package:gogo_app/presentation/sign_up/screen/sign_up_screen.dart';
+import 'package:flutter/cupertino.dart';
 
 class PageRouter {
   static final PageRouter _pageRouter = PageRouter.init();
@@ -11,20 +12,29 @@ class PageRouter {
 
   static const String splash = "splash";
   static const String login = "login";
+  static const String signUp = "signUp";
+
+  static GoRoute _customGoRoute(
+    String name,
+    Widget screen,
+  ) {
+    return GoRoute(
+      name: name,
+      path: "/$name",
+      pageBuilder: (context, state) {
+        return CupertinoPage(
+          child: screen,
+        );
+      },
+    );
+  }
 
   static final router = GoRouter(
     initialLocation: "/$splash",
     routes: [
-      GoRoute(
-        name: splash,
-        path: "/$splash",
-        builder: (_, __) => /*splash screen 넣기 */ SexPage(),
-      ),
-      GoRoute(
-        name: login,
-        path: "/$login",
-        builder: (_, __) => LogInScreen(),
-      ),
+      _customGoRoute(splash, LogInScreen()),
+      _customGoRoute(login, LogInScreen()),
+      _customGoRoute(signUp, SignUpScreen()),
     ],
   );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  bloc:
+    dependency: "direct main"
+    description:
+      name: bloc
+      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -70,6 +78,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: "1046d719fbdf230330d3443187cc33cc11963d15c9089f6cc56faa42a4c5f0cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -184,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -208,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 
   flutter_svg: ^2.0.17
   go_router: ^14.8.1
+  bloc: ^9.0.0
+  flutter_bloc: ^9.1.0
 
 
 dev_dependencies:


### PR DESCRIPTION
## 💡 개요

- 각각의 Auth페이지에 필요한 상태관리를 만들었습니다
- 만든 상태관리를 적용시켜 기능을 추가했습니다

## 📃 작업내용

- School 페이지 

[Screen_recording_20250305_200602.webm](https://github.com/user-attachments/assets/76f60f0e-4b84-4a2b-af62-093436fc099c)

- Name페이지 

[Screen_recording_20250305_200637.webm](https://github.com/user-attachments/assets/ba058bfe-e68b-4ef3-9fc1-d6d4fc8842b8)

- Number 페이지

[Screen_recording_20250305_200710.webm](https://github.com/user-attachments/assets/86f7e02f-107a-4e30-9872-cf5489ac62e1)

- Sex페이지

[Screen_recording_20250305_200721.webm](https://github.com/user-attachments/assets/b4ba8d22-2a9f-4833-bf90-1c35bc3a3229)

## 🙋‍♂️ 질문사항

- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
