### PR TITLE
🔀 :: (#129) 자동 로그인 에러 수정

### DIFF
--- a/lib/data/data_sources/token_data_source/token_data_source_impl.dart
+++ b/lib/data/data_sources/token_data_source/token_data_source_impl.dart
@@ -37,7 +37,7 @@ class TokenDataSourceImpl implements TokenDataSource {
     print("🔄 saveToken: ${token.accessToken} ${token.refreshToken}");
     await _storage.write(key: _accessTokenKey, value: token.accessToken);
     await _storage.write(key: _refreshTokenKey, value: token.refreshToken);
-    if (token.authority != null && token.authority != '') {
+    if (token.authority?.isNotEmpty == true) {
       await _storage.write(key: _authority, value: token.authority);
     }
   }

--- a/lib/data/data_sources/token_data_source/token_data_source_impl.dart
+++ b/lib/data/data_sources/token_data_source/token_data_source_impl.dart
@@ -37,7 +37,7 @@ class TokenDataSourceImpl implements TokenDataSource {
     print("🔄 saveToken: ${token.accessToken} ${token.refreshToken}");
     await _storage.write(key: _accessTokenKey, value: token.accessToken);
     await _storage.write(key: _refreshTokenKey, value: token.refreshToken);
-    if (token.authority != null || token.authority != '') {
+    if (token.authority != null && token.authority != '') {
       await _storage.write(key: _authority, value: token.authority);
     }
   }

--- a/lib/presentation/profile/screen/profile_screen.dart
+++ b/lib/presentation/profile/screen/profile_screen.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gogo_app/design_system/theme/icon.dart';
 import 'package:gogo_app/router.dart';
 import '../../../design_system/component/stage/gogo_stage_card_component.dart';
 import '../../../design_system/theme/color.dart';
-import '../../../design_system/theme/icon.dart';
 import '../../../design_system/theme/typography.dart';
-import '../Widget/profile_card_component.dart';
+import '../widget/profile_card_component.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});


### PR DESCRIPTION
## 💡 개요

- 자동 로그인 부분의 캐싱되는 Authority의 조건문을 수정

## 📃 작업내용

```dart
if (token.authority != null || token.authority != '') {
      await _storage.write(key: _authority, value: token.authority);
    }
```

=> 

```dart
if (token.authority != null && token.authority != '') {
      await _storage.write(key: _authority, value: token.authority);
    }
```

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
