### PR TITLE
🔀 :: (#172) 팀 확정 페이지 퍼블리싱 및 api 연결

### DIFF
--- a/lib/presentation/team_application/screen/team_application_screen.dart
+++ b/lib/presentation/team_application/screen/team_application_screen.dart
@@ -94,6 +94,7 @@ class TeamApplicationScreen extends StatelessWidget {
                                     List.generate(matches.length, (index) {
                                   final SearchGameItem game = matches[index];
                                   return GameWidget(
+                                    stageId: stageId,
                                     game: game,
                                     isManger: isManger,
                                   );

--- a/lib/presentation/team_application/widget/game_widget.dart
+++ b/lib/presentation/team_application/widget/game_widget.dart
@@ -131,7 +131,12 @@ class GameWidget extends StatelessWidget {
                       width: 148,
                     ),
                     GogoDefaultButton(
-                      onTap: () {},
+                      onTap: () => context.goNamed(
+                        queryParameters: {
+                          'gameId': game.gameId.toString(),
+                        },
+                        PageRouter.teamConfirmed,
+                      ),
                       text: "종료하기",
                       color: GogoColors.error,
                       width: 148,

--- a/lib/presentation/team_application/widget/game_widget.dart
+++ b/lib/presentation/team_application/widget/game_widget.dart
@@ -15,10 +15,15 @@ import '../../../design_system/component/tag/gogo_borderless_tag_component.dart'
 import '../../../design_system/theme/icon.dart';
 
 class GameWidget extends StatelessWidget {
+  final int stageId;
   final SearchGameItem game;
   final bool isManger;
 
-  const GameWidget({super.key, required this.game, required this.isManger});
+  const GameWidget(
+      {super.key,
+      required this.game,
+      required this.isManger,
+      required this.stageId});
 
   String _getGameCategoryText(GameType type) {
     switch (type) {
@@ -131,12 +136,11 @@ class GameWidget extends StatelessWidget {
                       width: 148,
                     ),
                     GogoDefaultButton(
-                      onTap: () => context.goNamed(
-                        queryParameters: {
-                          'gameId': game.gameId.toString(),
-                        },
-                        PageRouter.teamConfirmed,
-                      ),
+                      onTap: () => context
+                          .pushNamed(PageRouter.teamConfirmed, queryParameters: {
+                        'stageId': stageId.toString(),
+                        'gameId': game.gameId.toString(),
+                      }),
                       text: "종료하기",
                       color: GogoColors.error,
                       width: 148,

--- a/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_bloc.dart
+++ b/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_bloc.dart
@@ -1,0 +1,28 @@
+import 'package:bloc/bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gogo_app/data/repositories/stage/stage_repository.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/confirm/stage_confirm_event.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/confirm/stage_confirm_state.dart';
+import 'package:gogo_app/presentation/team_create/bloc/team_create_event.dart';
+import 'package:gogo_app/presentation/team_create/bloc/team_create_state.dart';
+
+class StageConfirmBloc extends Bloc<StageConfirmEvent, StageConfirmState> {
+  StageConfirmBloc() : super(StageConfirmInitial()) {
+    on<PostStageConfirmEvent>(_onPostStageConfirmEvent);
+  }
+
+  final StageRepository _stageRepository =
+      GetIt.instance.get<StageRepository>();
+
+  void _onPostStageConfirmEvent(
+      PostStageConfirmEvent event, Emitter<StageConfirmState> emit) async {
+    emit(StageConfirmLoading());
+    try {
+      await _stageRepository.confirmStage(
+          event.stageId, event.stateConfirmRequest);
+      emit(StageConfirmSuccess());
+    } catch (e) {
+      emit(StageConfirmFailure(errorMessage: e.toString()));
+    }
+  }
+}

--- a/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_event.dart
+++ b/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_event.dart
@@ -1,0 +1,17 @@
+import 'package:gogo_app/data/models/stage/handle_stage/team_apply_request.dart';
+
+import '../../../../data/models/stage/handle_stage/stage_confirm_request.dart';
+
+abstract class StageConfirmEvent {
+  const StageConfirmEvent();
+}
+
+class PostStageConfirmEvent extends StageConfirmEvent {
+  final int stageId;
+  final StateConfirmRequest stateConfirmRequest;
+
+  const PostStageConfirmEvent(
+    this.stageId, {
+    required this.stateConfirmRequest,
+  });
+}

--- a/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_state.dart
+++ b/lib/presentation/team_confirmed/bloc/confirm/stage_confirm_state.dart
@@ -1,0 +1,23 @@
+abstract class StageConfirmState {
+  const StageConfirmState();
+}
+
+class StageConfirmInitial extends StageConfirmState {
+  const StageConfirmInitial();
+}
+
+class StageConfirmLoading extends StageConfirmState {
+  const StageConfirmLoading();
+}
+
+class StageConfirmSuccess extends StageConfirmState {
+  const StageConfirmSuccess();
+}
+
+class StageConfirmFailure extends StageConfirmState {
+  final String errorMessage;
+
+  const StageConfirmFailure({
+    required this.errorMessage,
+  });
+}

--- a/lib/presentation/team_confirmed/bloc/data/get_temp_team_bloc.dart
+++ b/lib/presentation/team_confirmed/bloc/data/get_temp_team_bloc.dart
@@ -1,0 +1,26 @@
+import 'package:bloc/bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/data/get_temp_team_event.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/data/get_temp_team_state.dart';
+
+import '../../../../data/models/stage/search_stage/search_team_temp_response.dart';
+import '../../../../data/repositories/stage/stage_repository.dart';
+
+
+class GetTempTeamBloc extends Bloc<TempTeamEvent, GetTempTeamState> {
+  final StageRepository _stageRepository = GetIt.instance<StageRepository>();
+
+  GetTempTeamBloc() : super(GetTempTeamInitial()) {
+    on<GetTempTeamEvent>(_getGameEventHandler);
+  }
+
+  void _getGameEventHandler(GetTempTeamEvent event, Emitter<GetTempTeamState> emit) async {
+    emit(GetTempTeamLoading());
+    try {
+      SearchTempTeamResponse tempTeamResponse = await _stageRepository.getTempTeams(event.gameId);
+      emit(GetTempTeamLoaded(tempTeamResponse: tempTeamResponse));
+    } catch (e) {
+      emit(GetTempTeamError(message: e.toString()));
+    }
+  }
+}

--- a/lib/presentation/team_confirmed/bloc/data/get_temp_team_event.dart
+++ b/lib/presentation/team_confirmed/bloc/data/get_temp_team_event.dart
@@ -1,0 +1,7 @@
+class TempTeamEvent {}
+
+class GetTempTeamEvent extends TempTeamEvent {
+  final int gameId;
+
+  GetTempTeamEvent({required this.gameId});
+}

--- a/lib/presentation/team_confirmed/bloc/data/get_temp_team_state.dart
+++ b/lib/presentation/team_confirmed/bloc/data/get_temp_team_state.dart
@@ -1,0 +1,21 @@
+
+
+import '../../../../data/models/stage/search_stage/search_team_temp_response.dart';
+
+sealed class GetTempTeamState {}
+
+final class GetTempTeamInitial extends GetTempTeamState {}
+
+class GetTempTeamLoading extends GetTempTeamState {}
+
+class GetTempTeamLoaded extends GetTempTeamState {
+  final SearchTempTeamResponse tempTeamResponse;
+
+  GetTempTeamLoaded({required this.tempTeamResponse});
+}
+
+class GetTempTeamError extends GetTempTeamState {
+  final String message;
+
+  GetTempTeamError({required this.message});
+}

--- a/lib/presentation/team_confirmed/bloc/widget/team_select_bloc.dart
+++ b/lib/presentation/team_confirmed/bloc/widget/team_select_bloc.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'team_select_event.dart';
+import 'team_select_state.dart';
+
+class TeamSelectBloc extends Bloc<TeamSelectEvent, TeamSelectState> {
+  TeamSelectBloc() : super(const TeamSelectState()) {
+    on<ToggleTeamSelection>((event, emit) {
+      final newSet = Set<int>.from(state.selectedTeamIds);
+      if (newSet.contains(event.teamId)) {
+        newSet.remove(event.teamId);
+      } else {
+        newSet.add(event.teamId);
+      }
+      emit(state.copyWith(selectedTeamIds: newSet));
+    });
+  }
+}

--- a/lib/presentation/team_confirmed/bloc/widget/team_select_event.dart
+++ b/lib/presentation/team_confirmed/bloc/widget/team_select_event.dart
@@ -1,0 +1,17 @@
+import 'package:equatable/equatable.dart';
+
+abstract class TeamSelectEvent extends Equatable {
+  const TeamSelectEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class ToggleTeamSelection extends TeamSelectEvent {
+  final int teamId;
+
+  const ToggleTeamSelection(this.teamId);
+
+  @override
+  List<Object> get props => [teamId];
+}

--- a/lib/presentation/team_confirmed/bloc/widget/team_select_state.dart
+++ b/lib/presentation/team_confirmed/bloc/widget/team_select_state.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class TeamSelectState extends Equatable {
+  final Set<int> selectedTeamIds;
+
+  const TeamSelectState({this.selectedTeamIds = const {}});
+
+  TeamSelectState copyWith({Set<int>? selectedTeamIds}) {
+    return TeamSelectState(
+      selectedTeamIds: selectedTeamIds ?? this.selectedTeamIds,
+    );
+  }
+
+  @override
+  List<Object> get props => [selectedTeamIds];
+}

--- a/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
+++ b/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gogo_app/design_system/component/tag/gogo_tag_component.dart';
+import 'package:gogo_app/design_system/component/top_bar/gogo_top_bar.dart';
+import 'package:gogo_app/design_system/theme/color.dart';
+import 'package:gogo_app/design_system/theme/icon.dart';
+import 'package:gogo_app/design_system/theme/typography.dart';
+import 'package:gogo_app/presentation/team_confirmed/widget/team_confirmed_widget.dart';
+
+import '../../../data/models/stage/search_stage/search_team_temp_response.dart';
+import '../bloc/widget/team_select_bloc.dart';
+import '../bloc/widget/team_select_event.dart';
+import '../bloc/widget/team_select_state.dart';
+
+class TeamConfirmedScreen extends StatelessWidget {
+  TeamConfirmedScreen({super.key});
+
+  final List<TempTeam> teams = [
+    TempTeam(teamId: 1, teamName: '팀 이름1', participantCount: 1),
+    TempTeam(teamId: 2, teamName: '팀 이름2', participantCount: 2),
+    TempTeam(teamId: 3, teamName: '팀 이름3', participantCount: 3),
+    TempTeam(teamId: 4, teamName: '팀 이름4', participantCount: 4),
+    TempTeam(teamId: 5, teamName: '팀 이름5', participantCount: 5),
+    TempTeam(teamId: 6, teamName: '팀 이름6', participantCount: 6),
+    TempTeam(teamId: 7, teamName: '팀 이름7', participantCount: 7),
+    TempTeam(teamId: 8, teamName: '팀 이름8', participantCount: 8),
+    TempTeam(teamId: 9, teamName: '팀 이름9', participantCount: 9),
+    TempTeam(teamId: 10, teamName: '팀 이름10', participantCount: 10),
+    TempTeam(teamId: 11, teamName: '팀 이름11', participantCount: 11),
+    TempTeam(teamId: 12, teamName: '팀 이름12', participantCount: 12),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: BlocProvider(
+          create: (_) => TeamSelectBloc(),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: GogoTopBar(title: '경기 이름', onBackTap: () {}),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                  builder: (context, state) {
+                    return Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '현제 등록된 팀들',
+                          style: GogoTypography.caption1Extrabold
+                              .copyWith(color: GogoColors.white),
+                        ),
+                        Row(
+                          children: [
+                            Text(
+                              '선택된 팀 개수',
+                              style: GogoTypography.caption3Semibold
+                                  .copyWith(color: GogoColors.gray500),
+                            ),
+                            SizedBox(width: 10),
+                            Text(
+                              '${state.selectedTeamIds.length}',
+                              style: GogoTypography.caption2Semibold
+                                  .copyWith(color: GogoColors.white),
+                            ),
+                            SizedBox(width: 12),
+                            GogoTagComponent(
+                              icon: GogoIcons.check(color: GogoColors.main500),
+                              color: GogoColors.main500,
+                              text: '팀확정 하기',
+                            )
+                          ],
+                        )
+                      ],
+                    );
+                  },
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                    builder: (context, state) {
+                      return SingleChildScrollView(
+                        child: Column(
+                          children: teams.map((team) {
+                            final isSelected =
+                            state.selectedTeamIds.contains(team.teamId);
+                            return TeamConfirmedWidget(
+                              team: team,
+                              isSelected: isSelected,
+                              onTap: () {
+                                context
+                                    .read<TeamSelectBloc>()
+                                    .add(ToggleTeamSelection(team.teamId));
+                              },
+                            );
+                          }).toList(),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
+++ b/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
@@ -5,112 +5,121 @@ import 'package:gogo_app/design_system/component/top_bar/gogo_top_bar.dart';
 import 'package:gogo_app/design_system/theme/color.dart';
 import 'package:gogo_app/design_system/theme/icon.dart';
 import 'package:gogo_app/design_system/theme/typography.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/data/get_temp_team_event.dart';
 import 'package:gogo_app/presentation/team_confirmed/widget/team_confirmed_widget.dart';
 
 import '../../../data/models/stage/search_stage/search_team_temp_response.dart';
+import '../../loading/screens/loadaing_page.dart';
+import '../bloc/data/get_temp_team_bloc.dart';
+import '../bloc/data/get_temp_team_state.dart';
 import '../bloc/widget/team_select_bloc.dart';
 import '../bloc/widget/team_select_event.dart';
 import '../bloc/widget/team_select_state.dart';
 
 class TeamConfirmedScreen extends StatelessWidget {
-  TeamConfirmedScreen({super.key});
+  final int gameId;
 
-  final List<TempTeam> teams = [
-    TempTeam(teamId: 1, teamName: '팀 이름1', participantCount: 1),
-    TempTeam(teamId: 2, teamName: '팀 이름2', participantCount: 2),
-    TempTeam(teamId: 3, teamName: '팀 이름3', participantCount: 3),
-    TempTeam(teamId: 4, teamName: '팀 이름4', participantCount: 4),
-    TempTeam(teamId: 5, teamName: '팀 이름5', participantCount: 5),
-    TempTeam(teamId: 6, teamName: '팀 이름6', participantCount: 6),
-    TempTeam(teamId: 7, teamName: '팀 이름7', participantCount: 7),
-    TempTeam(teamId: 8, teamName: '팀 이름8', participantCount: 8),
-    TempTeam(teamId: 9, teamName: '팀 이름9', participantCount: 9),
-    TempTeam(teamId: 10, teamName: '팀 이름10', participantCount: 10),
-    TempTeam(teamId: 11, teamName: '팀 이름11', participantCount: 11),
-    TempTeam(teamId: 12, teamName: '팀 이름12', participantCount: 12),
-  ];
+  const TeamConfirmedScreen({super.key, required this.gameId});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
         child: BlocProvider(
-          create: (_) => TeamSelectBloc(),
-          child: Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: GogoTopBar(title: '경기 이름', onBackTap: () {}),
-              ),
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
-                  builder: (context, state) {
-                    return Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          '현제 등록된 팀들',
-                          style: GogoTypography.caption1Extrabold
-                              .copyWith(color: GogoColors.white),
-                        ),
-                        Row(
-                          children: [
-                            Text(
-                              '선택된 팀 개수',
-                              style: GogoTypography.caption3Semibold
-                                  .copyWith(color: GogoColors.gray500),
-                            ),
-                            SizedBox(width: 10),
-                            Text(
-                              '${state.selectedTeamIds.length}',
-                              style: GogoTypography.caption2Semibold
-                                  .copyWith(color: GogoColors.white),
-                            ),
-                            SizedBox(width: 12),
-                            GogoTagComponent(
-                              icon: GogoIcons.check(color: GogoColors.main500),
-                              color: GogoColors.main500,
-                              text: '팀확정 하기',
-                            )
-                          ],
-                        )
-                      ],
-                    );
-                  },
-                ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
-                    builder: (context, state) {
-                      return SingleChildScrollView(
-                        child: Column(
-                          children: teams.map((team) {
-                            final isSelected =
-                            state.selectedTeamIds.contains(team.teamId);
-                            return TeamConfirmedWidget(
-                              team: team,
-                              isSelected: isSelected,
-                              onTap: () {
-                                context
-                                    .read<TeamSelectBloc>()
-                                    .add(ToggleTeamSelection(team.teamId));
-                              },
+          create: (context) =>
+              GetTempTeamBloc()..add(GetTempTeamEvent(gameId: gameId)),
+          child: BlocBuilder<GetTempTeamBloc, GetTempTeamState>(
+            builder: (context, state) {
+              if (state is GetTempTeamLoading || state is GetTempTeamInitial) {
+                return LoadingPage();
+              }
+              // Game 목록과 개수를 상태에서 가져오기
+              List<TempTeam> teams = [];
+              if (state is GetTempTeamLoaded) {
+                teams = state.tempTeamResponse.team;
+              } else if (state is GetTempTeamError) {
+                return Center(child: Text('에러 발생: ${state.message}'));
+              }
+
+              return BlocProvider(
+                create: (_) => TeamSelectBloc(),
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: GogoTopBar(title: '경기 이름', onBackTap: () {}),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                        builder: (context, state) {
+                          return Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                '현제 등록된 팀들',
+                                style: GogoTypography.caption1Extrabold
+                                    .copyWith(color: GogoColors.white),
+                              ),
+                              Row(
+                                children: [
+                                  Text(
+                                    '선택된 팀 개수',
+                                    style: GogoTypography.caption3Semibold
+                                        .copyWith(color: GogoColors.gray500),
+                                  ),
+                                  SizedBox(width: 10),
+                                  Text(
+                                    '${state.selectedTeamIds.length}',
+                                    style: GogoTypography.caption2Semibold
+                                        .copyWith(color: GogoColors.white),
+                                  ),
+                                  SizedBox(width: 12),
+                                  GogoTagComponent(
+                                    icon: GogoIcons.check(
+                                        color: GogoColors.main500),
+                                    color: GogoColors.main500,
+                                    text: '팀확정 하기',
+                                  )
+                                ],
+                              )
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                          builder: (context, state) {
+                            return SingleChildScrollView(
+                              child: Column(
+                                children: teams.map((team) {
+                                  final isSelected = state.selectedTeamIds
+                                      .contains(team.teamId);
+                                  return TeamConfirmedWidget(
+                                    team: team,
+                                    isSelected: isSelected,
+                                    onTap: () {
+                                      context.read<TeamSelectBloc>().add(
+                                          ToggleTeamSelection(team.teamId));
+                                    },
+                                  );
+                                }).toList(),
+                              ),
                             );
-                          }).toList(),
+                          },
                         ),
-                      );
-                    },
-                  ),
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-            ],
+              );
+            },
           ),
         ),
       ),
     );
   }
 }
-

--- a/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
+++ b/lib/presentation/team_confirmed/screen/team_confirmed_screen.dart
@@ -1,15 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:gogo_app/design_system/component/tag/gogo_tag_component.dart';
 import 'package:gogo_app/design_system/component/top_bar/gogo_top_bar.dart';
 import 'package:gogo_app/design_system/theme/color.dart';
 import 'package:gogo_app/design_system/theme/icon.dart';
 import 'package:gogo_app/design_system/theme/typography.dart';
+import 'package:gogo_app/presentation/team_confirmed/bloc/confirm/stage_confirm_bloc.dart';
 import 'package:gogo_app/presentation/team_confirmed/bloc/data/get_temp_team_event.dart';
 import 'package:gogo_app/presentation/team_confirmed/widget/team_confirmed_widget.dart';
 
+import '../../../data/models/stage/handle_stage/stage_confirm_request.dart';
 import '../../../data/models/stage/search_stage/search_team_temp_response.dart';
 import '../../loading/screens/loadaing_page.dart';
+import '../bloc/confirm/stage_confirm_event.dart';
+import '../bloc/confirm/stage_confirm_state.dart';
 import '../bloc/data/get_temp_team_bloc.dart';
 import '../bloc/data/get_temp_team_state.dart';
 import '../bloc/widget/team_select_bloc.dart';
@@ -17,104 +22,102 @@ import '../bloc/widget/team_select_event.dart';
 import '../bloc/widget/team_select_state.dart';
 
 class TeamConfirmedScreen extends StatelessWidget {
+  final int stageId;
   final int gameId;
 
-  const TeamConfirmedScreen({super.key, required this.gameId});
+  const TeamConfirmedScreen(
+      {super.key, required this.gameId, required this.stageId});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: BlocProvider(
-          create: (context) =>
-              GetTempTeamBloc()..add(GetTempTeamEvent(gameId: gameId)),
+        child: MultiBlocProvider(
+          providers: [
+            BlocProvider(
+                create: (_) =>
+                    GetTempTeamBloc()..add(GetTempTeamEvent(gameId: gameId))),
+            BlocProvider(create: (_) => TeamSelectBloc()),
+            BlocProvider(create: (_) => StageConfirmBloc()), // 추가하고 싶은 Bloc
+          ],
           child: BlocBuilder<GetTempTeamBloc, GetTempTeamState>(
             builder: (context, state) {
               if (state is GetTempTeamLoading || state is GetTempTeamInitial) {
                 return LoadingPage();
               }
-              // Game 목록과 개수를 상태에서 가져오기
-              List<TempTeam> teams = [];
-              if (state is GetTempTeamLoaded) {
-                teams = state.tempTeamResponse.team;
-              } else if (state is GetTempTeamError) {
+
+              if (state is GetTempTeamError) {
                 return Center(child: Text('에러 발생: ${state.message}'));
               }
 
-              return BlocProvider(
-                create: (_) => TeamSelectBloc(),
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: GogoTopBar(title: '경기 이름', onBackTap: () {}),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
-                        builder: (context, state) {
-                          return Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                '현제 등록된 팀들',
+              final teams = (state as GetTempTeamLoaded).tempTeamResponse.team;
+
+              return Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: GogoTopBar(title: '경기 이름', onBackTap: context.pop),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                      builder: (context, state) {
+                        return Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text('현제 등록된 팀들',
                                 style: GogoTypography.caption1Extrabold
-                                    .copyWith(color: GogoColors.white),
-                              ),
-                              Row(
-                                children: [
-                                  Text(
-                                    '선택된 팀 개수',
+                                    .copyWith(color: GogoColors.white)),
+                            Row(
+                              children: [
+                                Text('선택된 팀 개수',
                                     style: GogoTypography.caption3Semibold
-                                        .copyWith(color: GogoColors.gray500),
-                                  ),
-                                  SizedBox(width: 10),
-                                  Text(
-                                    '${state.selectedTeamIds.length}',
+                                        .copyWith(color: GogoColors.gray500)),
+                                SizedBox(width: 10),
+                                Text('${state.selectedTeamIds.length}',
                                     style: GogoTypography.caption2Semibold
-                                        .copyWith(color: GogoColors.white),
-                                  ),
-                                  SizedBox(width: 12),
-                                  GogoTagComponent(
+                                        .copyWith(color: GogoColors.white)),
+                                SizedBox(width: 12),
+                                GogoTagComponent(
                                     icon: GogoIcons.check(
                                         color: GogoColors.main500),
                                     color: GogoColors.main500,
                                     text: '팀확정 하기',
-                                  )
-                                ],
-                              )
-                            ],
+                                    ontap: () {}),
+                              ],
+                            )
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
+                        builder: (context, state) {
+                          return SingleChildScrollView(
+                            child: Column(
+                              children: teams.map((team) {
+                                final isSelected =
+                                    state.selectedTeamIds.contains(team.teamId);
+                                return TeamConfirmedWidget(
+                                  team: team,
+                                  isSelected: isSelected,
+                                  onTap: () {
+                                    context
+                                        .read<TeamSelectBloc>()
+                                        .add(ToggleTeamSelection(team.teamId));
+                                  },
+                                );
+                              }).toList(),
+                            ),
                           );
                         },
                       ),
                     ),
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: BlocBuilder<TeamSelectBloc, TeamSelectState>(
-                          builder: (context, state) {
-                            return SingleChildScrollView(
-                              child: Column(
-                                children: teams.map((team) {
-                                  final isSelected = state.selectedTeamIds
-                                      .contains(team.teamId);
-                                  return TeamConfirmedWidget(
-                                    team: team,
-                                    isSelected: isSelected,
-                                    onTap: () {
-                                      context.read<TeamSelectBloc>().add(
-                                          ToggleTeamSelection(team.teamId));
-                                    },
-                                  );
-                                }).toList(),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               );
             },
           ),

--- a/lib/presentation/team_confirmed/widget/team_confirmed_widget.dart
+++ b/lib/presentation/team_confirmed/widget/team_confirmed_widget.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:gogo_app/data/models/stage/search_stage/search_team_temp_response.dart';
+import 'package:gogo_app/design_system/theme/color.dart';
+import 'package:gogo_app/design_system/theme/icon.dart';
+import 'package:gogo_app/design_system/theme/typography.dart';
+
+class TeamConfirmedWidget extends StatelessWidget {
+  final TempTeam team;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const TeamConfirmedWidget({
+    super.key,
+    required this.team,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Container(
+        width: double.infinity,
+        height: 58,
+        padding: EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          color: GogoColors.gray700,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              team.teamName,
+              style: GogoTypography.caption1Extrabold
+                  .copyWith(color: GogoColors.white),
+            ),
+            Row(
+              children: [
+                Text(
+                  '팀 자세히 보기',
+                  style: GogoTypography.caption1Semibold
+                      .copyWith(color: GogoColors.gray300),
+                ),
+                IconButton(
+                  onPressed: onTap,
+                  icon: isSelected
+                      ? GogoIcons.checkboxFilled(
+                          width: 24, height: 24, color: GogoColors.main500)
+                      : GogoIcons.checkboxOutlined(
+                          width: 24, height: 24, color: GogoColors.gray300),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -26,6 +26,7 @@ import 'package:gogo_app/presentation/splash/screen/splash_screen.dart';
 import 'package:gogo_app/presentation/stage/screen/stage_screen.dart';
 import 'package:gogo_app/presentation/stage_create/screen/stage_create_screen.dart';
 import 'package:gogo_app/presentation/team_application/screen/team_application_screen.dart';
+import 'package:gogo_app/presentation/team_confirmed/screen/team_confirmed_screen.dart';
 
 class PageRouter {
   static final PageRouter _pageRouter = PageRouter.init();
@@ -54,6 +55,7 @@ class PageRouter {
   static const String matchTeamInfo = "matchTeamInfo";
   static const String teamApplication = 'teamApplication';
   static const String createTeam = "createTeam";
+  static const String teamConfirmed = "teamConfirmed";
 
   static GoRoute _customGoRoute({
     required String name,
@@ -96,6 +98,18 @@ class PageRouter {
         name: stage,
         screen: StageScreen(),
         routes: [
+          GoRoute(
+            name: teamConfirmed,
+            path: '$teamConfirmed',
+            pageBuilder: (context, state) {
+              final gameId = int.parse(state.uri.queryParameters['gameId']!);
+              return CupertinoPage(
+                child: TeamConfirmedScreen(
+                  gameId: gameId,
+                ),
+              );
+            },
+          ),
           GoRoute(
             name: teamApplication,
             path: '/$teamApplication',

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -102,29 +102,34 @@ class PageRouter {
             name: teamConfirmed,
             path: '$teamConfirmed',
             pageBuilder: (context, state) {
-              final gameId = int.parse(state.uri.queryParameters['gameId']!);
+              final stageId =
+              int.parse(state.uri.queryParameters['stageId']!);
+              final gameId =
+              int.parse(state.uri.queryParameters['gameId']!);
               return CupertinoPage(
                 child: TeamConfirmedScreen(
+                  stageId: stageId,
                   gameId: gameId,
                 ),
               );
             },
           ),
           GoRoute(
-            name: teamApplication,
-            path: '/$teamApplication',
-            pageBuilder: (context, state) {
-              final stageId = int.parse(state.uri.queryParameters['stageId']!);
-              final isMaintainer =
-                  bool.parse(state.uri.queryParameters['isMaintainer']!);
-              return CupertinoPage(
-                child: TeamApplicationScreen(
-                  stageId: stageId,
-                  isManger: isMaintainer,
-                ),
-              );
-            },
-          ),
+              name: teamApplication,
+              path: '/$teamApplication',
+              pageBuilder: (context, state) {
+                final stageId =
+                    int.parse(state.uri.queryParameters['stageId']!);
+                final isMaintainer =
+                    bool.parse(state.uri.queryParameters['isMaintainer']!);
+                return CupertinoPage(
+                  child: TeamApplicationScreen(
+                    stageId: stageId,
+                    isManger: isMaintainer,
+                  ),
+                );
+              },
+              ),
           GoRoute(
             name: home,
             path: "/$home",


### PR DESCRIPTION
## 💡 개요
팀 확정 페이지 퍼블리싱 및 api 연결
## 📃 작업내용
팀 확정 페이지 퍼블리싱 및 api 연결
팀 선택 bloc 코드 작성
팀 데이터 불러오는 bloc 작성
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 영상
[Screen_recording_20250529_170606.webm](https://github.com/user-attachments/assets/e29da018-5729-4821-bf5e-609b60df2caf)

